### PR TITLE
Events should be sorted by date #22

### DIFF
--- a/content/events/huawei-developer-conference.md
+++ b/content/events/huawei-developer-conference.md
@@ -1,7 +1,7 @@
 ---
 title: "Huawei Developer Conference"
 date: 2019-12-12T05:10:00-00:00
-link: "https://consumer.huawei.com/en/event/hdc2019/"
+link: "https://www.huaweicloud.com/HDC.Cloud.html"
 categories: ["events"]
 event_date: Feb 11-12, 2020
 expire_date: 2020-02-12


### PR DESCRIPTION
Updated home layout file to respect the expire_date content param.
Includes date fix for Huawei event (#18).

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>